### PR TITLE
Authorization adds

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -16,18 +16,17 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from api.views import *
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from api.views import login_view, DashboardTokenObtainPairView, DriverTokenObtainPairView
+from rest_framework_simplejwt.views import TokenRefreshView
 from django.conf import settings
 from django.conf.urls.static import static
 
-
-
 urlpatterns = [
     path('', login_view, name='login'),
-    path('admin/', admin.site.urls),
-    path("api/token/", TokenObtainPairView.as_view(), name="get_token"),
+    path("api/token/", DashboardTokenObtainPairView.as_view(), name="get_token"),
+    path("api/driver/token/", DriverTokenObtainPairView.as_view(), name="driver_get_token"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="refresh"),
     path('api-auth/', include('rest_framework.urls')),
     path('api/', include('api.urls')), 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -24,7 +24,7 @@ const Header = ({ darkMode, toggleDarkMode, toggleSidebar }) => {
             />
               {/* <MdSpaceDashboard className='h-8 me-3 text-xl text-violet-500' /> */}
               <span className='self-center text-xl font-semibold text-white sm:text-2xl whitespace-nowrap dark:text-white ml-60'>
-                Chinook Transport Services
+                Chinook Transport Services Supervisor Dashboard
               </span>
             </a>
           </div>


### PR DESCRIPTION
Restricted views are guarded with "@supervisor_required" which checks both is_staff=true and is_active=true. Also added a couple token serializers, one for the dashboard and one for drivers. This way a driver can't even log into the web app dashboard and if they did, they would still be very limited to what actions they could perform. The new endpoint for driver JWT is "api/driver/token/" as I left the default for the supervisors. Added "@permission_classes([IsAuthenticated])" to every other view for basic security as well.